### PR TITLE
T1090 port proxy reg key

### DIFF
--- a/atomics/T1090/T1090.yaml
+++ b/atomics/T1090/T1090.yaml
@@ -3,31 +3,61 @@ attack_technique: T1090
 display_name: Connection Proxy
 
 atomic_tests:
-- name: Connection Proxy
-  description: |
-    Enable traffic redirection.
+  - name: Connection Proxy
+    description: |
+      Enable traffic redirection.
 
-    Note that this test may conflict with pre-existing system configuration.
+      Note that this test may conflict with pre-existing system configuration.
 
-  supported_platforms:
-    - macos
-    - linux
+    supported_platforms:
+      - macos
+      - linux
 
-  input_arguments:
-    proxy_server:
-      description: Proxy server URL (host:port)
-      type: url
-      default: 127.0.0.1:8080
+    input_arguments:
+      proxy_server:
+        description: Proxy server URL (host:port)
+        type: url
+        default: 127.0.0.1:8080
 
-    proxy_scheme:
-      description: Protocol to proxy (http or https)
-      type: string
-      default: http
+      proxy_scheme:
+        description: Protocol to proxy (http or https)
+        type: string
+        default: http
 
-  executor:
-    name: sh
-    command: |
-      export #{proxy_scheme}_proxy=#{proxy_server}
-    cleanup_command: |
-      unset http_proxy
-      unset https_proxy
+    executor:
+      name: sh
+      command: |
+        export #{proxy_scheme}_proxy=#{proxy_server}
+      cleanup_command: |
+        unset http_proxy
+        unset https_proxy
+
+  - name: portproxy reg key
+    description: |
+      Adds a registry key to set up a proxy on the endpoint at
+      HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PortProxy\v4tov4
+
+    supported_platforms:
+      - windows
+
+    input_arguments:
+      listenport:
+        description: Specifies the IPv4 port, by port number or service name, on which to listen.
+        type: string
+        default: 1337
+
+      connectport:
+        description: Specifies the IPv4 port, by port number or service name, to which to connect. If connectport is not specified, the default is the value of listenport on the local computer.
+        type: string
+        default: 1337
+
+      connectaddress:
+        description: Specifies the IPv4 address to which to connect. Acceptable values are IP address, computer NetBIOS name, or computer DNS name. If an address is not specified, the default is the local computer.
+        type: string
+        default: 127.0.0.1
+
+    executor:
+      name: powershell
+      elevation_required: true
+      command: netsh interface portproxy add v4tov4 listenport=#{listenport} connectport=#{connectport} connectaddress=#{connectaddress}
+      cleanup_command: netsh interface portproxy delete v4tov4 listenport=#{listenport}  


### PR DESCRIPTION
adds test that uses netsh to set a reg key establishing a proxy service on the endpoint

**Details:**
<!-- Insert details about this change here. Please include as much detail as possible -->

**Testing:**
<!-- Note any testing done, local or automated here. -->

**Associated Issues:**
<!-- Please link any issues that this pull request impacts or fixes. -->